### PR TITLE
fixing some matlab stuff

### DIFF
--- a/lib/rugments/lexers/matlab.rb
+++ b/lib/rugments/lexers/matlab.rb
@@ -50,14 +50,15 @@ module Rugments
 
         rule %r{[(){};:,\/\\\]\[]}, Punctuation
 
-        rule /~=|==|<<|>>|[-~+\/*%=<>&^|.]/, Operator
+        rule /~=|==|<<|>>|[-~+\/*%=<>&^|.@]/, Operator
 
         rule /(\d+\.\d*|\d*\.\d+)(e[+-]?[0-9]+)?/i, Num::Float
         rule /\d+e[+-]?[0-9]+/i, Num::Float
         rule /\d+L/, Num::Integer::Long
         rule /\d+/, Num::Integer
 
-        rule /'/, Str::Single, :string
+        rule /'(?=(.*'))/, Str::Single, :string # should be: rule /(?<![\]\)\w\.])'/i, Str::Single, :string
+        rule /'/, Operator
       end
 
       state :string do

--- a/lib/rugments/lexers/matlab.rb
+++ b/lib/rugments/lexers/matlab.rb
@@ -56,8 +56,14 @@ module Rugments
         rule /\d+e[+-]?[0-9]+/i, Num::Float
         rule /\d+L/, Num::Integer::Long
         rule /\d+/, Num::Integer
-
-        rule /'(?=(.*'))/, Str::Single, :string # should be: rule /(?<![\]\)\w\.])'/i, Str::Single, :string
+		
+        # TODO should probably be: 
+		# rule /(?<![\]\)\w\.])'/i, Str::Single, :string
+		# unfortunately look-behind assertion do not work
+		# This rule leads to false recognition of strings
+		# when using something like c = a' + b'; but all other
+		# cases should be working
+        rule /'(?=(.*'))/, Str::Single, :string 
         rule /'/, Operator
       end
 

--- a/lib/rugments/lexers/matlab.rb
+++ b/lib/rugments/lexers/matlab.rb
@@ -58,11 +58,11 @@ module Rugments
         rule /\d+/, Num::Integer
 		
         # TODO should probably be: 
-		# rule /(?<![\]\)\w\.])'/i, Str::Single, :string
-		# unfortunately look-behind assertion do not work
-		# This rule leads to false recognition of strings
-		# when using something like c = a' + b'; but all other
-		# cases should be working
+        # rule /(?<![\]\)\w\.])'/i, Str::Single, :string
+        # unfortunately look-behind assertion do not work
+        # This rule leads to false recognition of strings
+        # when using something like c = a' + b'; but all other
+        # cases should be working
         rule /'(?=(.*'))/, Str::Single, :string 
         rule /'/, Operator
       end

--- a/lib/rugments/lexers/objective_c.rb
+++ b/lib/rugments/lexers/objective_c.rb
@@ -7,7 +7,7 @@ module Rugments
       title 'Objective-C'
       desc 'an extension of C commonly used to write Apple software'
       aliases 'objc'
-      filenames '*.m', '*.h'
+      filenames '*.h'#,'*.m'
 
       mimetypes 'text/x-objective_c', 'application/x-objective_c'
 

--- a/lib/rugments/lexers/objective_c.rb
+++ b/lib/rugments/lexers/objective_c.rb
@@ -7,7 +7,7 @@ module Rugments
       title 'Objective-C'
       desc 'an extension of C commonly used to write Apple software'
       aliases 'objc'
-      filenames '*.h'#,'*.m'
+      filenames '*.m', '*.h'
 
       mimetypes 'text/x-objective_c', 'application/x-objective_c'
 


### PR DESCRIPTION
(string vs transpose) and possibly breaking parts of objective_c (*.m is now matlab)
now something like
var = [0 0 0 0]';
does not break the entire file. But as written as comment it should actually be something like 
rule /(?<![\]\)\w\.])'/i, Str::Single, :string
which would allow to parse the following in the right manner (where both ' should be operators):
a'+b'=c;
Unfortunately this expression is not working (at least not in gitlab 7.8)