### PR TITLE
Pass lexer options to enumeration to support continue use case

### DIFF
--- a/lib/rugments/lexers.rb
+++ b/lib/rugments/lexers.rb
@@ -348,7 +348,7 @@ module Rugments
     # @option opts :continue
     #   Continue the lex from the previous state (i.e. don't call #reset!)
     def lex(string, opts = {})
-      return enum_for(:lex, string) unless block_given?
+      return enum_for(:lex, string, opts) unless block_given?
 
       Lexer.assert_utf8!(string)
 


### PR DESCRIPTION
There is no way to use the `continue` option in `lexer.lex` if the enumeration mode is used. This will be needed to support proper syntax highlighting when blocks of code are streamed into the lexer, as in the case of `git blame`.

Will submit a PR to rouge as well.
