### PR TITLE
Recognize ".vb" files as Visual Basic code

### DIFF
--- a/lib/rugments/lexers/vb.rb
+++ b/lib/rugments/lexers/vb.rb
@@ -5,7 +5,7 @@ module Rugments
       desc 'Visual Basic'
       tag 'vb'
       aliases 'visualbasic'
-      filenames '*.vbs'
+      filenames '*.vbs', '*.vb'
       mimetypes 'text/x-visualbasic', 'application/x-visualbasic'
 
       def self.keywords


### PR DESCRIPTION
".vb" is the default extension of Visual Basic project on Visual Studio. 
So files with ".vb" extension should be recognized as Visual Basic files.
